### PR TITLE
#166822174 Delete endpoints return 200 status codes

### DIFF
--- a/property/views.py
+++ b/property/views.py
@@ -105,7 +105,7 @@ class PropertyDetailView(generics.RetrieveUpdateDestroyAPIView):
         found_property.soft_delete()
         return Response({
             "message": "Successfully deleted the property"
-        }, status=status.HTTP_204_NO_CONTENT)
+        }, status=status.HTTP_200_OK)
 
     def patch(self, request, slug, **kwargs):
         """

--- a/tests/property/test_views.py
+++ b/tests/property/test_views.py
@@ -207,7 +207,7 @@ class PropertyViewTests(BaseTest):
         request = self.factory.delete(url)
         force_authenticate(request, user=self.user1)
         response = view(request, slug=self.property11.slug)
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_that_client_admins_need_to_have_client_before_they_can_create_property(self):  # noqa
         """

--- a/tests/transactions/test_views.py
+++ b/tests/transactions/test_views.py
@@ -160,7 +160,7 @@ class TestClientAccountDetailsViews(BaseTest):
 
         res = self.view2(request2, account_number=account_number)
 
-        self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertIn('Account details successfully deleted', str(res.data))
 
     def test_delete_account_details_non_existent(self):

--- a/transactions/views.py
+++ b/transactions/views.py
@@ -124,7 +124,7 @@ class RetrieveUpdateDeleteAccountDetailsAPIView(RetrieveUpdateDestroyAPIView):
         self.check_object_permissions(request, account_details)
         account_details.soft_delete()
         response = {"message": "Account details successfully deleted"}
-        return Response({"data": response}, status=status.HTTP_204_NO_CONTENT)
+        return Response({"data": response}, status=status.HTTP_200_OK)
 
     def put(self, request, account_number):
 


### PR DESCRIPTION
## Description ##
Because we want messages returned when we delete property, we should use the HTTP 200 status code. HTTP 204 does not allow any messages to be contained in the response.

## Type of change ##
Please select the relevant option
- [x] Bug fix(a non-breaking change which fixes an issue)
- [ ] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? ##
Please describe the tests that you ran to verify your changes
- [ ] End to end test
- [ ] Integration test
- [ ] unit test

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## Related Pivotal Tracker stories ##
[#166822174](https://www.pivotaltracker.com/story/show/166822174)

