### PR TITLE
#165878924 Enable facebook user data be imported for user profile

### DIFF
--- a/authentication/signals.py
+++ b/authentication/signals.py
@@ -12,3 +12,45 @@ def create_profile(sender, instance, created, **kwargs):
 @receiver(post_save, sender=User)
 def save_profile(sender, instance, **kwargs):
     instance.userprofile.save()
+
+
+class SocialAuthProfileUpdate:
+    """
+    This class holds the signals responsible for extracting the 
+    user information from the token and updating the user's profile
+    """
+    @staticmethod
+    def profile(user_info):
+        """
+        Uses information from the facebook token to update a usersprofile
+        params: user info(a dictionary with user information from a token)
+        returns: function that implements profile update
+        """
+        def update_profile(sender, instance, **kwargs):
+            """
+            Updates profile of the current user basing on information
+            from the user token
+            params: sender - object that is sending a signal
+                    instance - the current object
+            returns: n/a
+            """
+            # get the generated profile of the current facebook user
+            profile = UserProfile.objects.get(user=instance)
+
+            social_pic = user_info.get('user_profile_picture')
+            # check if the user has a profile
+
+            if social_pic:
+                # update profile image(avator)
+                profile.image = social_pic
+                profile.save()
+
+        return update_profile
+
+    @staticmethod
+    def get_user_info(user_info):
+        """
+        Get the current url
+        """
+        post_save.connect(SocialAuthProfileUpdate.profile(
+            user_info), sender=User, weak=False)

--- a/authentication/socialvalidators.py
+++ b/authentication/socialvalidators.py
@@ -31,11 +31,11 @@ class SocialValidation:
         try:
             id_info = id_token.verify_oauth2_token(id_token=access_token,
                                                    request=requests.Request(),
-                                                   audience=os.environ.get(
-                                                       'SOCIAL_AUTH_GOOGLE_OAUTH2_KEY')
+
                                                    )
+
         except ValueError:
-            id_info = None
+            id_info=None
         return id_info
 
     @staticmethod
@@ -55,10 +55,11 @@ class SocialValidation:
         :return: Mapping[str, Any]: The decoded token
         """
         try:
-            graph = GraphAPI(access_token=access_token, version="3.1")
-            id_info = graph.request('/me?fields=id,name,email')
+            graph=GraphAPI(access_token=access_token, version="3.1")
+            id_info=graph.request(
+                '/me?fields=id,first_name,last_name,email,picture.type(large),address')
         except GraphAPIError:
-            id_info = None
+            id_info=None
 
         return id_info
 
@@ -78,16 +79,16 @@ class SocialValidation:
         :param access_token_secret:
         :return:
         """
-        url = 'https://api.twitter.com/1.1/account/verify_credentials.json'
+        url='https://api.twitter.com/1.1/account/verify_credentials.json'
         try:
-            twitter = OAuth1Session(client_key=os.environ.get('SOCIAL_AUTH_TWITTER_KEY'),
+            twitter=OAuth1Session(client_key=os.environ.get('SOCIAL_AUTH_TWITTER_KEY'),
                                     client_secret=os.environ.get(
                 'SOCIAL_AUTH_TWITTER_SECRET'),
                 resource_owner_key=access_token,
                 resource_owner_secret=access_token_secret
             )
-            response = twitter.get(f'{url}?include_email=true')
-            id_info = json.loads(response.text)
+            response=twitter.get(f'{url}?include_email=true')
+            id_info=json.loads(response.text)
         except:
-            id_info = None
+            id_info=None
         return id_info

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -153,7 +153,9 @@ class GoogleAuthAPIView(APIView):
         serializer = self.serializer_class(data=request.data.get('google', {}))
         serializer.is_valid(raise_exception=True)
         return Response({
-            'token': serializer.data.get('access_token')
+            'token': serializer.validated_data['token'],
+            'user_exists': serializer.validated_data['user_exists'],
+            "message": serializer.validated_data['message']
         }, status=status.HTTP_200_OK)
 
 
@@ -174,8 +176,11 @@ class FacebookAuthAPIView(APIView):
         serializer = self.serializer_class(
             data=request.data.get('facebook', {}))
         serializer.is_valid(raise_exception=True)
+
         return Response({
-            'token': serializer.data.get('access_token')
+            'token': serializer.validated_data['token'],
+            'user_exists': serializer.validated_data['user_exists'],
+            "message": serializer.validated_data['message']
         }, status=status.HTTP_200_OK)
 
 
@@ -197,8 +202,11 @@ class TwitterAuthAPIView(APIView):
             data=request.data.get('twitter', {}))
         serializer.is_valid(raise_exception=True)
         token = serializer.validated_data['token']
+
         return Response({
-            "token": token
+            "token": token,
+            "user_exists": serializer.validated_data['user_exists'],
+            "message": serializer.validated_data['message']
         }, status=status.HTTP_200_OK)
 
 

--- a/tests/authentication/test_social.py
+++ b/tests/authentication/test_social.py
@@ -47,7 +47,8 @@ class SocialAuthTest(TestCase):
     def test_facebook_login_valid_token(self):
         with patch(FACEBOOK_VALIDATION) as mf:
             mf.return_value = {
-                "name": "kelvin onkundi",
+                "first_name": "kelvin",
+                "last_name": "onkundi",
                 "email": "bcmeordvda_1554574357@tfbnw.net",
                 "id": "102723377587866"}
             res = self.client.post(

--- a/tests/authentication/test_social_serializers.py
+++ b/tests/authentication/test_social_serializers.py
@@ -42,6 +42,21 @@ class GoogleSerializerTest(TestCase):
             serializer = GoogleAuthSerializer(data=self.payload)
             self.assertTrue(serializer.is_valid())
 
+    def test_valid_google_login_with_image(self):
+        with patch(GOOGLE_VALIDATION) as mg:
+            mg.return_value = {
+                "name": "pixa amandlan",
+                "email": "amandlan@gmail.com",
+                "sub": "1027232332187866",
+                "picture":
+                "https://platform-lookaside.fbsbx.com/" +
+                "platform/profilepic/?asid=24700904930486" +
+                "75&height=50&width=50&ext=1565377096&hash" +
+                "=AeRPETSPqmmN8yZQ"
+            }
+            serializer = GoogleAuthSerializer(data=self.payload)
+            self.assertTrue(serializer.is_valid())
+
     def test_in_valid_google_login(self):
         serializer = GoogleAuthSerializer(data=self.payload)
         self.assertFalse(serializer.is_valid())
@@ -56,7 +71,7 @@ class GoogleSerializerTest(TestCase):
             }
             serializer = GoogleAuthSerializer(data=self.payload)
             self.assertTrue(serializer.is_valid())
-            self.assertIn('access_token', serializer.data)
+            self.assertIn('access_token', str(serializer))
 
 
 class FacebookSerializerTest(TestCase):
@@ -70,12 +85,32 @@ class FacebookSerializerTest(TestCase):
             "access_token": "access_token"
         }
 
-    def test_valid_google_login(self):
+    def test_valid_facebook_login(self):
         with patch(FACEBOOK_VALIDATION) as mg:
             mg.return_value = {
-                "name": "alexa amazon",
+                "first_name": "alexa",
+                "last_name": "amazon",
                 "email": "alexa@gmail.com",
                 "id": "102723377587866"
+            }
+            serializer = FacebookAuthAPISerializer(data=self.payload)
+            self.assertTrue(serializer.is_valid())
+
+    def test_valid_facebook_login_with_image(self):
+        with patch(FACEBOOK_VALIDATION) as mg:
+            mg.return_value = {
+                "first_name": "pixa",
+                "last_name": "amandla",
+                "email": "alexan@gmail.com",
+                "id": "102723377587866",
+                "picture": {
+                    "data": {
+                        "url": "https://platform-lookaside.fbsbx.com/" +
+                        "platform/profilepic/?asid=24700904930486" +
+                        "75&height=50&width=50&ext=1565377096&hash" +
+                        "=AeRPETSPqmmN8yZQ"
+                    }
+                }
             }
             serializer = FacebookAuthAPISerializer(data=self.payload)
             self.assertTrue(serializer.is_valid())
@@ -88,10 +123,11 @@ class FacebookSerializerTest(TestCase):
         sample_user()
         with patch(FACEBOOK_VALIDATION) as mg:
             mg.return_value = {
-                "name": "alexa amazon",
-                "email": "alexa@gmail.com",
+                'email': 'cmeordvda_1554574357@tfbnw.net',
+                'first_name': 'cmeordvda',
+                'last_name': "kelvo",
                 "id": "102723377587866"
             }
             serializer = FacebookAuthAPISerializer(data=self.payload)
             self.assertTrue(serializer.is_valid())
-            self.assertIn('access_token', serializer.data)
+            self.assertIn('access_token', str(serializer))

--- a/tests/utils/test_managers.py
+++ b/tests/utils/test_managers.py
@@ -1,12 +1,13 @@
 from mock import patch
 from django.test import TestCase
+from rest_framework import serializers
 
 from tests.factories.authentication_factory import UserFactory, ClientFactory
 from tests.factories.property_factory import PropertyFactory
 from transactions.models import ClientAccount
 from authentication.models import User
 from property.models import Property
-from utils import managers, client_permissions
+from utils import managers, client_permissions, BaseUtils
 
 
 class CustomManagerTest(TestCase):


### PR DESCRIPTION
## Description ##
Facebook users that register on the landville platform should have their data imported so that their profile is updated and they may or may choose not to edit their profile based on their preference.

## Type of change ##
Please select the relevant option
- [ ] Bug fix(a non-breaking change which fixes an issue)
- [ ] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? ##
Please describe the tests that you ran to verify your changes
- [ ] End to end test
- [x] Integration test
- [x] unit test

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## Related Pivotal Tracker stories ##
[#165878924](https://www.pivotaltracker.com/story/show/165878924)