### PR TITLE
168046827 Make city on trending properties query optional

### DIFF
--- a/tests/property/test_views.py
+++ b/tests/property/test_views.py
@@ -811,9 +811,7 @@ class PropertyViewTests(BaseTest):
         force_authenticate(request, user=self.user1)
         view = TrendingPropertyView.as_view()
         response = view(request)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(str(response.data.get('errors')),
-                         'Please specify a city')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_trending_property_at_a_specific_time(self):
         """


### PR DESCRIPTION
## Title

Make city on trending properties query optional

## Description

A user should be able to get trending properties with or without the city query parameter. This is useful because, in the homepage, it would not be fit to set the city while fetching trending properties. reason being users may be viewing the app from a location that is different from the currently set city.
These changes make sure that the endpoint returns the list of trending properties regardless of the location, but will still not break the functionality for devs that want to get the properties by location.

## Type of change
Please select the relevant option

- [ ]   Bug fix(a non-breaking change which fixes an issue)
- [x]   New feature(a non-breaking change which adds functionality)
- [ ]   Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ]   This change requires a documentation update

How Has This Been Tested?
Please describe the tests that you ran to verify your changes

- [ ]   End to end test
- [ ]   Integration test
- [x]   unit test

Checklist:
  My code follows the style guidelines of this project

- [x]   I have linted my code prior to submission
- [ ]   I have made corresponding changes to the documentation
- [x]   My changes generate no new warnings
- [ ]   I have added tests that prove my fix is effective or that my feature works
- [x]   New and existing tests pass locally with my changes

### How can this be manually tested?
1. Pull this branch and checkout to it. `ft-get-trending-properties-without-location-168046827`
2. Start the server
3. Go to the trending properties endpoint
`http://127.0.0.1:8000/api/v1/properties/trending/` you will be able to get the properties that are trending without specifying the city.

Related Pivotal Tracker stories
[#168046827](https://www.pivotaltracker.com/n/projects/2343772/stories/168046827)