### PR TITLE
Fix redirect on validation of international payment

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -39,3 +39,4 @@ export CLOUDINARY_API_SECRET="cloudinary secret key"
 export REDIS_URL="redis://localhost:6379"
 
 export FRONT_END_URL='frontend url'
+FRONT_END_INTPAYMENT_URL='frontend_url_international_payment'

--- a/transactions/views.py
+++ b/transactions/views.py
@@ -378,7 +378,7 @@ def foreign_card_validation_response(request):
     :param request: DRF request object
     :return: JSON response
     """
-    domain = os.environ.get('FRONT_END_URL')
+    domain = os.environ.get('FRONT_END_INTPAYMENT_URL')
 
     resp = json.loads(request.query_params['response'])
     verify_resp = TransactionServices.verify_payment(resp['txRef'])
@@ -403,12 +403,12 @@ def foreign_card_validation_response(request):
 
     else:
         return HttpResponseRedirect(
-            f"{domain}/international-payment/status/" +
+            f"{domain}" +
             f"?message={verify_resp.get('message')}&status=failure"
         )
 
     return HttpResponseRedirect(
-        f"{domain}/international-payment/status/"
+        f"{domain}"
         + f"?message={message}&status=success"
     )
 


### PR DESCRIPTION
## Description ##
Add the entire url for the link redirected to upon validation of international payment to the .env file.
This will make it easy to change the redirect url to the transactions page that is still being implemented in the frontend.

## Type of change ##
Please select the relevant option
- [x] Bug fix(a non-breaking change which fixes an issue)
- [ ] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? ##
Please describe the tests that you ran to verify your changes
- [ ] End to end test
- [x] Integration test
- [ ] unit test

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## How to test this PR
- Make an international transaction using the url `/api/v1/transactions/card-foreign/` as an authenticated user
Pass this information as the body
```
{
    "cardno": "4556052704172643",
    "cvv": "899",
    "expirymonth": "01",
    "expiryyear": "21",
    "amount": "20",
    "billingzip": "07205",
    "billingcity": "billingcity",
    "billingaddress": "billingaddress",
    "billingstate": "NJ",
    "billingcountry": "UK",
    "save_card":true,
    "purpose": "Saving"
 
}
```
You should be able to get a response similar to this
```
{
    "message": "https://ravesandboxapi.flutterwave.com/mockvbvpage?ref=FLW-MOCK-9bc0e5f82f7caabb00227ca7ef34f4dd&code=00&message=Approved. Successful&receiptno=RN1566566373923",
    "txRef": "LANDVILLE-2019-08-23 13:19:30.496558"
}
```
- Copy the entire `message` returned and paste that in your browser to navigate to the link that is returned
- A page will request for the OTP sent to your phone 
- Enter 12345 and submit.
This should redirect you to the frontend

## Related Pivotal Tracker stories ##
[#168077072](https://www.pivotaltracker.com/story/show/168077072)
