### PR TITLE
#168374861 Fix display of approved client companies.

### DIFF
--- a/authentication/views.py
+++ b/authentication/views.py
@@ -344,7 +344,7 @@ class ClientListView(generics.GenericAPIView):
     def get_queryset(self):
         """ Returns all active client companies  """
 
-        return Client.active_objects.all()
+        return Client.active_objects.all_approved()
 
     def get(self, request):
         """ Handles retrieving all existing client companies """
@@ -609,8 +609,8 @@ class ClientReviewsView(generics.ListCreateAPIView):
         queryset = ClientReview.active_objects.all_objects().filter(
             client=client)
         if queryset:
-            return queryset	
-        else:	
+            return queryset
+        else:
             raise Http404
 
     def create(self, request, *args, **kwargs):


### PR DESCRIPTION
## Description ##
- Display only approved clients list.
As a user, I want to view a list of client companies. The result displays all active client companies regardless of whether they're approved already or not. This fix is meant to solve this.

## Type of change ##
Please select the relevant option
- [x] Bug fix(a non-breaking change which fixes an issue)
- [ ] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? ##
Please describe the tests that you ran to verify your changes
- [x] End to end test
- [ ] Integration test
- [ ] unit test

## How to test the functionality? ##
- Setup the repo locally.
- Checkout to `bg-display-approved-clients-168374861`.
- Run the python server `python manage.py runserver`
- Open postman and run a `Get` request on `http://127.0.0.1:8000/api/v1/auth/clients/` 
- The returned list should only contain approved client companies


## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## Related Pivotal Tracker stories ##
[#168374861](https://www.pivotaltracker.com/story/show/168374861)