### PR TITLE
 #168398881 Unpublish property on delete

### DIFF
--- a/property/views.py
+++ b/property/views.py
@@ -512,9 +512,8 @@ class TrendingPropertyView(generics.ListAPIView):
 
         city = self.request.query_params.get('city')
 
-        query_results = Property.active_objects.filter(
+        query_results = Property.active_objects.is_published().filter(
             last_viewed__date__gte=date,
-            is_published=True,
             is_sold=False,
             view_count__gte=1).order_by('-view_count', 'last_viewed')
         if city:


### PR DESCRIPTION
## Description ##
- Unpublish a property at delete.
On deletion of a property the property is first unpublished then deleted this way it never shows in published properties after deletion unlike before.

## Type of change ##
Please select the relevant option
- [x] Bug fix(a non-breaking change which fixes an issue)
- [ ] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? ##
Please describe the tests that you ran to verify your changes
- [x] End to end test
- [ ] Integration test
- [ ] unit test

## How to test the functionality? ##
- Setup the repo locally.
- Checkout to `bg-unpublish-on-delete-168398881`.
- Make migrations with `python manage.py makemigrations`
- Run `python manage.py migrate`
- **This is crucial because the some fundamental project models files have been changed.**
- Run the python server `python manage.py runserver`
- Open postman and run a `Delete` request on `http://127.0.0.1:8000/api/v1/properties/get/{slug}` 


## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## Related Pivotal Tracker stories ##
[#168398881](https://www.pivotaltracker.com/story/show/168398881)
